### PR TITLE
Add Windows support with cross-platform Node.js activator

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,19 @@ This skill fixes that. When Claude Code discovers something non-obvious (a debug
 
 ### Step 1: Clone the skill
 
-**User-level (recommended)**
+**Linux/Mac (user-level, recommended)**
 
 ```bash
 git clone https://github.com/blader/Claudeception.git ~/.claude/skills/claudeception
 ```
 
-**Project-level**
+**Windows (PowerShell)**
+
+```powershell
+git clone https://github.com/blader/Claudeception.git "$env:USERPROFILE\.claude\skills\claudeception"
+```
+
+**Project-level (any platform)**
 
 ```bash
 git clone https://github.com/blader/Claudeception.git .claude/skills/claudeception
@@ -24,7 +30,65 @@ git clone https://github.com/blader/Claudeception.git .claude/skills/claudecepti
 
 The skill can activate via semantic matching, but a hook ensures it evaluates every session for extractable knowledge.
 
-1. Create the hooks directory and copy the script:
+#### All Platforms (Node.js - Recommended)
+
+The Node.js version works on Linux, Mac, and Windows since Claude Code requires Node.js.
+
+**Linux/Mac:**
+
+```bash
+mkdir -p ~/.claude/hooks
+cp ~/.claude/skills/claudeception/scripts/claudeception-activator.js ~/.claude/hooks/
+```
+
+Add to `~/.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ~/.claude/hooks/claudeception-activator.js"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+**Windows (PowerShell):**
+
+```powershell
+mkdir -Force "$env:USERPROFILE\.claude\hooks"
+cp "$env:USERPROFILE\.claude\skills\claudeception\scripts\claudeception-activator.js" "$env:USERPROFILE\.claude\hooks\"
+```
+
+Add to `%USERPROFILE%\.claude\settings.json`:
+
+```json
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node %USERPROFILE%\\.claude\\hooks\\claudeception-activator.js"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+#### Linux/Mac Alternative (Bash)
+
+If you prefer bash, you can use the shell script instead:
 
 ```bash
 mkdir -p ~/.claude/hooks
@@ -32,7 +96,7 @@ cp ~/.claude/skills/claudeception/scripts/claudeception-activator.sh ~/.claude/h
 chmod +x ~/.claude/hooks/claudeception-activator.sh
 ```
 
-2. Add the hook to your Claude settings (`~/.claude/settings.json`):
+Add to `~/.claude/settings.json`:
 
 ```json
 {
@@ -50,6 +114,8 @@ chmod +x ~/.claude/hooks/claudeception-activator.sh
   }
 }
 ```
+
+---
 
 If you already have a `settings.json`, merge the `hooks` configuration into it.
 

--- a/scripts/claudeception-activator.js
+++ b/scripts/claudeception-activator.js
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+
+// Claudeception Auto-Activation Hook
+// This hook ensures the claudeception skill evaluates every interaction
+// for extractable knowledge worth preserving.
+//
+// Installation:
+//   1. Copy this script to ~/.claude/hooks/
+//   2. Add to ~/.claude/settings.json (see README for details)
+
+console.log(`━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+🧠 MANDATORY SKILL EVALUATION REQUIRED
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+CRITICAL: After completing this user request, you MUST evaluate whether
+it produced extractable knowledge using the claudeception skill.
+
+EVALUATION PROTOCOL (NON-NEGOTIABLE):
+
+1. COMPLETE the user's request first
+2. EVALUATE: Ask yourself:
+   - Did this require non-obvious investigation or debugging?
+   - Was the solution something that would help in future similar situations?
+   - Did I discover something not immediately obvious from documentation?
+
+3. IF YES to any question above:
+   ACTIVATE: Use Skill(claudeception) NOW to extract the knowledge
+
+4. IF NO to all questions:
+   SKIP: No skill extraction needed
+
+This is NOT optional. Failing to evaluate means valuable knowledge is lost.
+The claudeception skill will decide whether to actually create a new
+skill based on its quality criteria.
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━`);


### PR DESCRIPTION
## Summary

- Add `scripts/claudeception-activator.js` for cross-platform support
- Update README with Windows installation instructions
- Node.js version works on all platforms (Linux, Mac, Windows)
- Keep bash script as alternative for Linux/Mac users

## Why

The bash script doesn't work on Windows because:
1. `cmd.exe` doesn't expand `~` paths
2. Heredocs don't work properly in Git Bash on Windows

## Solution

A minimal Node.js script (just `console.log`) that:
- Works in both ESM and CommonJS environments
- Uses `%USERPROFILE%` on Windows (expands in cmd.exe)
- Uses `~` on Linux/Mac (expands in bash/zsh)

## Testing needed

- [x] Tested on Windows 
- [ ] **Needs testing on Mac**
- [ ] **Needs testing on Linux**

The `node ~/.claude/hooks/claudeception-activator.js` command should work on Mac/Linux if the shell expands `~`, but this hasn't been verified.

## Test plan

1. Copy script to `~/.claude/hooks/`
2. Add hook config to `settings.json` (see README)
3. Restart Claude Code
4. Submit a prompt - should see the skill evaluation message

---

🤖 Generated with [Claude Code](https://claude.ai/code)