### PR TITLE
Add Windows support with cross-platform Node.js activator

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,19 @@ This skill fixes that. When Claude Code discovers something non-obvious (a debug
 
 ### Step 1: Clone the skill
 
-**User-level (recommended)**
+**Linux/Mac (user-level, recommended)**
 
 ```bash
 git clone https://github.com/blader/Claudeception.git ~/.claude/skills/claudeception
 ```
 
-**Project-level**
+**Windows (PowerShell)**
+
+```powershell
+git clone https://github.com/blader/Claudeception.git "$env:USERPROFILE\.claude\skills\claudeception"
+```
+
+**Project-level (any platform)**
 
 ```bash
 git clone https://github.com/blader/Claudeception.git .claude/skills/claudeception
@@ -23,6 +29,8 @@ git clone https://github.com/blader/Claudeception.git .claude/skills/claudecepti
 ### Step 2: Set up the activation hook (recommended)
 
 The skill can activate via semantic matching, but a hook ensures it evaluates every session for extractable knowledge.
+
+#### Linux/Mac
 
 1. Create the hooks directory and copy the script:
 
@@ -50,6 +58,38 @@ chmod +x ~/.claude/hooks/claudeception-activator.sh
   }
 }
 ```
+
+#### Windows
+
+The bash script doesn't work on Windows. Use the Node.js version instead:
+
+1. Create the hooks directory and copy the script (PowerShell):
+
+```powershell
+mkdir -Force "$env:USERPROFILE\.claude\hooks"
+cp "$env:USERPROFILE\.claude\skills\claudeception\scripts\claudeception-activator.js" "$env:USERPROFILE\.claude\hooks\"
+```
+
+2. Add the hook to your Claude settings (`%USERPROFILE%\.claude\settings.json`):
+
+```json
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node %USERPROFILE%\\.claude\\hooks\\claudeception-activator.js"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+---
 
 If you already have a `settings.json`, merge the `hooks` configuration into it.
 

--- a/scripts/claudeception-activator.js
+++ b/scripts/claudeception-activator.js
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+
+// Claudeception Auto-Activation Hook
+// This hook ensures the claudeception skill evaluates every interaction
+// for extractable knowledge worth preserving.
+//
+// Installation:
+//   1. Copy this script to ~/.claude/hooks/
+//   2. Add to ~/.claude/settings.json (see README for details)
+
+console.log(`━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+🧠 MANDATORY SKILL EVALUATION REQUIRED
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+CRITICAL: After completing this user request, you MUST evaluate whether
+it produced extractable knowledge using the claudeception skill.
+
+EVALUATION PROTOCOL (NON-NEGOTIABLE):
+
+1. COMPLETE the user's request first
+2. EVALUATE: Ask yourself:
+   - Did this require non-obvious investigation or debugging?
+   - Was the solution something that would help in future similar situations?
+   - Did I discover something not immediately obvious from documentation?
+
+3. IF YES to any question above:
+   ACTIVATE: Use Skill(claudeception) NOW to extract the knowledge
+
+4. IF NO to all questions:
+   SKIP: No skill extraction needed
+
+This is NOT optional. Failing to evaluate means valuable knowledge is lost.
+The claudeception skill will decide whether to actually create a new
+skill based on its quality criteria.
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━`);


### PR DESCRIPTION
## Summary

- Add `scripts/claudeception-activator.js` for Windows support
- Update README with Windows installation instructions
- Keep bash script unchanged for Linux/Mac users

## Why

The bash script doesn't work on Windows because:
1. `cmd.exe` doesn't expand `~` paths
2. Heredocs behave differently in Git Bash

## Testing

- [x] Tested on Windows
- [ ] **Needs verification on Mac**
- [ ] **Needs verification on Linux**

---

🤖 Generated with [Claude Code](https://claude.ai/code)