### PR TITLE
feat: add native Windows/PowerShell activator hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,47 @@ chmod +x .claude/hooks/claudeception-activator.sh
 
 If you already have a `settings.json`, merge the `hooks` configuration into it.
 
+### Windows / PowerShell
+
+The activation hook is also available as a native PowerShell script for Windows users.
+
+1. Clone the skill (if you haven't already):
+
+```powershell
+git clone https://github.com/blader/Claudeception.git "$env:USERPROFILE\.claude\skills\claudeception"
+```
+
+2. Create the hooks directory and copy the PowerShell script:
+
+```powershell
+New-Item -ItemType Directory -Force -Path "$env:USERPROFILE\.claude\hooks"
+Copy-Item "$env:USERPROFILE\.claude\skills\claudeception\scripts\claudeception-activator.ps1" `
+          "$env:USERPROFILE\.claude\hooks\"
+```
+
+3. Add the hook to your Claude settings (`~/.claude/settings.json`):
+
+```json
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pwsh -File %USERPROFILE%\\.claude\\hooks\\claudeception-activator.ps1"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+> **Note:** Use `pwsh` (PowerShell 7+) rather than `powershell` for best compatibility. If you have existing hooks in `settings.json`, merge the `UserPromptSubmit` array into your existing `hooks` object.
+
+**Project-level installation** follows the same pattern — copy the `.ps1` to `.claude/hooks/` in your repo and reference it with a relative path in `.claude/settings.json`.
+
 The hook injects a reminder on every prompt that tells Claude to evaluate whether the current task produced extractable knowledge. This achieves higher activation rates than relying on semantic description matching alone.
 
 ## Usage

--- a/scripts/claudeception-activator.ps1
+++ b/scripts/claudeception-activator.ps1
@@ -12,6 +12,8 @@
 #   1. Copy this script to $env:USERPROFILE\.claude\hooks\
 #   2. Add to $env:USERPROFILE\.claude\settings.json (see README for details)
 
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+
 Write-Output @"
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 🧠 MANDATORY SKILL EVALUATION REQUIRED

--- a/scripts/claudeception-activator.ps1
+++ b/scripts/claudeception-activator.ps1
@@ -1,0 +1,42 @@
+#!/usr/bin/env pwsh
+
+# claudeception-activator.ps1
+# Native Windows/PowerShell activator hook for Claudeception.
+# Equivalent to scripts/claudeception-activator.sh for non-Unix environments.
+#
+# Hook type: UserPromptSubmit
+# Purpose: Outputs a reminder for Claude to evaluate whether the current task
+#          produced extractable knowledge worth saving as a reusable skill.
+#
+# Installation:
+#   1. Copy this script to $env:USERPROFILE\.claude\hooks\
+#   2. Add to $env:USERPROFILE\.claude\settings.json (see README for details)
+
+Write-Output @"
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+🧠 MANDATORY SKILL EVALUATION REQUIRED
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+CRITICAL: After completing this user request, you MUST evaluate whether
+it produced extractable knowledge using the claudeception skill.
+
+EVALUATION PROTOCOL (NON-NEGOTIABLE):
+
+1. COMPLETE the user's request first
+2. EVALUATE: Ask yourself:
+   - Did this require non-obvious investigation or debugging?
+   - Was the solution something that would help in future similar situations?
+   - Did I discover something not immediately obvious from documentation?
+
+3. IF YES to any question above:
+   ACTIVATE: Use Skill(claudeception) NOW to extract the knowledge
+
+4. IF NO to all questions:
+   SKIP: No skill extraction needed
+
+This is NOT optional. Failing to evaluate means valuable knowledge is lost.
+The claudeception skill will decide whether to actually create a new
+skill based on its quality criteria.
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+"@


### PR DESCRIPTION
## Summary

This project is currently 100% Shell with no Windows support. Windows users who want the `UserPromptSubmit` activation hook have no path that doesn't involve WSL or Git Bash.

- Adds `scripts/claudeception-activator.ps1` — a native PowerShell equivalent of `claudeception-activator.sh`, using the same plain-text stdout output mechanism and matching content/tone exactly (including the `MANDATORY`/`CRITICAL`/`NON-NEGOTIABLE` language and explicit `Skill(claudeception)` activation instruction)
- Adds a "Windows / PowerShell" subsection to the README Step 2 install section with copy/paste instructions and a `settings.json` example
- Includes `[Console]::OutputEncoding = [System.Text.Encoding]::UTF8` to ensure the `━` box-drawing characters render correctly — caught during testing, without this they silently render as `?`

## Test plan

- [x] `pwsh -File scripts/claudeception-activator.ps1` runs without errors and renders the full reminder block correctly
- [x] Script copied to `~/.claude/hooks/` and invoked via `pwsh -File %USERPROFILE%\.claude\hooks\claudeception-activator.ps1` — matches README instruction exactly
- [x] Tested on Windows 11 with PowerShell 7.4 and Claude Code

**Note:** The `Copy-Item` step in the README assumes the user has cloned post-merge (the `.ps1` won't be present in the skill directory until this PR lands).